### PR TITLE
特定の譜面が読み込まれない不具合を修正

### DIFF
--- a/音ゲー（仮）/GameScene/GameScene.swift
+++ b/音ゲー（仮）/GameScene/GameScene.swift
@@ -148,7 +148,8 @@ class GameScene: SKScene, AVAudioPlayerDelegate, YTPlayerViewDelegate, GSAppDele
         
         // notesにノーツの"　始　点　"を入れる
         do {
-            try parse(fileName: musicName.rawValue + ".bms")
+//            try parse(fileName: musicName.rawValue + ".bms")
+            try parse(fileName: "READY!!(小節長変更確認用).bms")
         }
         catch FileError.invalidName     (let msg) { print(msg) }
         catch FileError.notFound        (let msg) { print(msg) }

--- a/音ゲー（仮）/GameScene/GameScene.swift
+++ b/音ゲー（仮）/GameScene/GameScene.swift
@@ -148,8 +148,7 @@ class GameScene: SKScene, AVAudioPlayerDelegate, YTPlayerViewDelegate, GSAppDele
         
         // notesにノーツの"　始　点　"を入れる
         do {
-//            try parse(fileName: musicName.rawValue + ".bms")
-            try parse(fileName: "READY!!(小節長変更確認用).bms")
+            try parse(fileName: musicName.rawValue + ".bms")
         }
         catch FileError.invalidName     (let msg) { print(msg) }
         catch FileError.notFound        (let msg) { print(msg) }

--- a/音ゲー（仮）/GameScene/GameSceneParser.swift
+++ b/音ゲー（仮）/GameScene/GameSceneParser.swift
@@ -75,7 +75,7 @@ extension GameScene {   // bmsファイルを読み込む
             "LANE":      { value in if let num = Int(value) { self.laneNum = num } }
         ]
 
-        let headerEx = try! Regex("^#([A-Z][0-9A-Z]*) (.*)$")   // ヘッダの行にマッチ
+        let headerEx = try! Regex("^#([A-Z][0-9A-Z]*)( .*)?$")   // ヘッダの行にマッチ
         let mainDataEx = try! Regex("^#([0-9]{3})([0-9]{2}):(([0-9A-Z]{2})+)$") // メインデータの小節長変更命令以外にマッチ
         let barLengthEx = try! Regex("^#([0-9]{3})02:(([1-9]\\d*|0)(\\.\\d+)?)$") // メインデータの小節長変更命令にマッチ
 
@@ -83,7 +83,7 @@ extension GameScene {   // bmsファイルを読み込む
         for bmsLine in bmsData {
             if let match = headerEx.firstMatch(bmsLine) {
                 let item = match.groups[0]!
-                let value = match.groups[1]!
+                let value = String(match.groups[1]?.dropFirst() ?? "")  // nilでなければ空白を取り除く
                 // ヘッダをパース
                 if let headerInstruction = headerInstructionTable[item] {   // 辞書に該当する命令がある場合
                     headerInstruction(value)

--- a/音ゲー（仮）/Regex.swift
+++ b/音ゲー（仮）/Regex.swift
@@ -18,7 +18,7 @@ public struct Regex {
                 .map { i -> String? in
                     let range = res.range(at: i)
                     guard range.location != NSNotFound else {
-                        // ない可能性のある()だとnilのこともある ←どんなとき？？
+                        // ない可能性のある()だとnilのこともある ←"(hoge)?"とか
                         return nil
                     }
                     return text.substring(with: res.range(at: i))


### PR DESCRIPTION
スペースを含まないヘッダ命令が混ざっていた時に例外を投げてそれ以降の譜面が読み込まれていなかった。