### PR TITLE
バグ修正および仕様変更 #151

### DIFF
--- a/音ゲー（仮）/GameScene/GameScene.swift
+++ b/音ゲー（仮）/GameScene/GameScene.swift
@@ -50,8 +50,7 @@ class GameScene: SKScene, AVAudioPlayerDelegate, YTPlayerViewDelegate, GSAppDele
     let playMode: PlayMode
     let isAutoPlay: Bool
     
-    let judgeQueue = DispatchQueue(label: "judge_queue", qos: .userInteractive)    // キューに入れた処理内容を順番に実行(FPS落ち対策)
-    
+//    let judgeQueue = DispatchQueue(label: "judge_queue", qos: .userInteractive)    // キューに入れた処理内容を順番に実行(FPS落ち対策)
     
     // appの起動、終了等に関するデリゲート
     var appDelegate: AppDelegate!
@@ -373,9 +372,9 @@ class GameScene: SKScene, AVAudioPlayerDelegate, YTPlayerViewDelegate, GSAppDele
         
         // レーンの更新(ノーツ更新後に実行)
         lanes.filter({ !($0.isEmpty) }).forEach({ lane in
-            judgeQueue.async {
+//            judgeQueue.async {
                 lane.updateTimeLag(self.passedTime, self.BPMs)
-            }
+//            }
         })
         
 //        for lane in lanes {
@@ -403,8 +402,8 @@ class GameScene: SKScene, AVAudioPlayerDelegate, YTPlayerViewDelegate, GSAppDele
         } else {
             // 判定関係
             // middleの判定（同じところで長押しのやつ）
-            judgeQueue.async {
-                
+//            judgeQueue.async {
+
                 for gsTouch in self.allGSTouches {
                     
                     let pos = gsTouch.touch.location(in: self.view?.superview)
@@ -433,7 +432,7 @@ class GameScene: SKScene, AVAudioPlayerDelegate, YTPlayerViewDelegate, GSAppDele
                         }
                     }
                 }
-            }
+//            }
         }
         
         // 終了時刻が指定されていればその時刻でシーン移動

--- a/音ゲー（仮）/Lane.swift
+++ b/音ゲー（仮）/Lane.swift
@@ -34,7 +34,8 @@ class Lane {
     private var laneNotes: [Note] = []  // 最初に全部格納する！
     var isEmpty: Bool { return laneNotes.isEmpty }
     var headNote: Note? { return laneNotes.first }
-    func append(_ note: Note) { laneNotes.append(note) }
+    func append(_ note: Note) { self.laneNotes.append(note) }
+    func remove(_ note: Note) { if let i = laneNotes.index(of: note) { self.laneNotes.remove(at: i) } }
     func sort() { laneNotes.sort { $0.beat < $1.beat } }
     
     var storedFlickJudgeInformation: (timeLag: TimeInterval, touch: UITouch)? {// (判定予定時間(movedが呼ばれた時間), タッチ情報)

--- a/音ゲー（仮）/Note.swift
+++ b/音ゲー（仮）/Note.swift
@@ -311,8 +311,7 @@ class Middle: Note {
         }
         
         // 通過後のノーツはreturn
-        guard !(isJudged &&
-            image.isHidden && longImages.circle.isHidden && longImages.long.isHidden) else {
+        guard !(isJudged && image.isHidden && longImages.circle.isHidden && longImages.long.isHidden && positionOnLane < 0) else {
                 return
         }
         


### PR DESCRIPTION
ポーズ時、途中まで判定したロングノーツを最後まで判定済みにせず、始点ノーツを作ってロングノーツを再開できるように変更
MiddleがTapに変更された等に伴う、同時線の引き直しはしてない